### PR TITLE
Change react native sdk entry point to js

### DIFF
--- a/Gracetech.md
+++ b/Gracetech.md
@@ -1,0 +1,13 @@
+# GraceTech Jitsi Meet SDK
+
+## Notes
+React Native SDK has been modified to add `index.js` and `index.d.ts` files so that `index.js` will be imported by SDK users instead of `index.tsx`.
+This prevents type errors from the SDK from showing up when importing the SDK into another project and running `tsc` to type check the project.
+
+`index.js` and `index.d.ts` are generated and should be regenerated if `index.tsx` changes.
+
+### Steps to regenerate
+- Navigate to `react-native-sdk` directory
+- Run `npm run generate-index`
+- Delete all generated files except `react-native-sdk/index.js` and `react-native-sdk/index.d.ts`
+- Navigate to repo root and run `eslint --fix react-native-sdk/index.js` if needed to fix lint errors

--- a/react-native-sdk/.npmignore
+++ b/react-native-sdk/.npmignore
@@ -1,1 +1,4 @@
 *.tgz
+
+# Gracetech: SDK entry point changed to index.js. See Gracetech.md for details
+index.tsx

--- a/react-native-sdk/index.d.ts
+++ b/react-native-sdk/index.d.ts
@@ -1,0 +1,44 @@
+import './react/bootstrap.native';
+import React from 'react';
+import type { IRoomsInfo } from '../react/features/breakout-rooms/types';
+interface IEventListeners {
+    onAudioMutedChanged?: Function;
+    onVideoMutedChanged?: Function;
+    onConferenceBlurred?: Function;
+    onConferenceFocused?: Function;
+    onConferenceJoined?: Function;
+    onConferenceLeft?: Function;
+    onConferenceWillJoin?: Function;
+    onEnterPictureInPicture?: Function;
+    onParticipantJoined?: Function;
+    onParticipantLeft?: ({ id }: {
+        id: string;
+    }) => void;
+    onReadyToClose?: Function;
+}
+interface IUserInfo {
+    avatarURL: string;
+    displayName: string;
+    email: string;
+}
+interface IAppProps {
+    config: object;
+    eventListeners?: IEventListeners;
+    flags?: object;
+    room: string;
+    serverURL?: string;
+    style?: Object;
+    token?: string;
+    userInfo?: IUserInfo;
+}
+export interface JitsiRefProps {
+    close: Function;
+    setAudioMuted?: (muted: boolean) => void;
+    setVideoMuted?: (muted: boolean) => void;
+    getRoomsInfo?: () => IRoomsInfo;
+}
+/**
+ * Main React Native SDK component that displays a Jitsi Meet conference and gets all required params as props
+ */
+export declare const JitsiMeeting: React.ForwardRefExoticComponent<IAppProps & React.RefAttributes<JitsiRefProps>>;
+export {};

--- a/react-native-sdk/index.js
+++ b/react-native-sdk/index.js
@@ -1,0 +1,97 @@
+/* eslint-disable lines-around-comment,  no-undef, no-unused-vars  */
+// NB: This import must always come first.
+import './react/bootstrap.native';
+import React, { forwardRef, useEffect, useImperativeHandle, useLayoutEffect, useRef, useState } from 'react';
+import { View } from 'react-native';
+
+import { appNavigate } from './react/features/app/actions.native';
+import { App } from './react/features/app/components/App.native';
+import { setAudioMuted, setVideoMuted } from './react/features/base/media/actions';
+import { getRoomsInfo } from './react/features/breakout-rooms/functions';
+/**
+ * Main React Native SDK component that displays a Jitsi Meet conference and gets all required params as props
+ */
+export const JitsiMeeting = forwardRef((props, ref) => {
+    const [ appProps, setAppProps ] = useState({});
+    const app = useRef(null);
+    const { config, eventListeners, flags, room, serverURL, style, token, userInfo } = props;
+
+    // eslint-disable-next-line arrow-body-style
+    useImperativeHandle(ref, () => ({
+        close: () => {
+            const dispatch = app.current.state.store.dispatch;
+
+            dispatch(appNavigate(undefined));
+        },
+        setAudioMuted: muted => {
+            const dispatch = app.current.state.store.dispatch;
+
+            dispatch(setAudioMuted(muted));
+        },
+        setVideoMuted: muted => {
+            const dispatch = app.current.state.store.dispatch;
+
+            dispatch(setVideoMuted(muted));
+        },
+        getRoomsInfo: () => {
+            const state = app.current.state.store.getState();
+
+            return getRoomsInfo(state);
+        }
+    }));
+    useEffect(() => {
+        const urlObj = {
+            config,
+            jwt: token
+        };
+        let urlProps;
+
+        if (room.includes('://')) {
+            urlProps = {
+                ...urlObj,
+                url: room
+            };
+        } else {
+            urlProps = {
+                ...urlObj,
+                room,
+                serverURL
+            };
+        }
+        setAppProps({
+            'flags': flags,
+            'rnSdkHandlers': {
+                onAudioMutedChanged: eventListeners?.onAudioMutedChanged,
+                onVideoMutedChanged: eventListeners?.onVideoMutedChanged,
+                onConferenceBlurred: eventListeners?.onConferenceBlurred,
+                onConferenceFocused: eventListeners?.onConferenceFocused,
+                onConferenceJoined: eventListeners?.onConferenceJoined,
+                onConferenceWillJoin: eventListeners?.onConferenceWillJoin,
+                onConferenceLeft: eventListeners?.onConferenceLeft,
+                onEnterPictureInPicture: eventListeners?.onEnterPictureInPicture,
+                onParticipantJoined: eventListeners?.onParticipantJoined,
+                onParticipantLeft: eventListeners?.onParticipantLeft,
+                onReadyToClose: eventListeners?.onReadyToClose
+            },
+            'url': urlProps,
+            'userInfo': userInfo
+        });
+    }, []);
+    // eslint-disable-next-line arrow-body-style
+    useLayoutEffect(() => {
+        /**
+         * When you close the component you need to reset it.
+         * In some cases it needs to be added as the parent component may have been destroyed.
+         * Without this change the call remains active without having the jitsi screen.
+        */
+        return () => {
+            const dispatch = app.current?.state?.store?.dispatch;
+
+            dispatch && dispatch(appNavigate(undefined));
+        };
+    }, []);
+
+    return (<View style={style}>
+        <App {...appProps} ref={app}/>
+    </View>);
+});

--- a/react-native-sdk/package.json
+++ b/react-native-sdk/package.json
@@ -1,8 +1,8 @@
 {
     "name": "@jitsi/react-native-sdk",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "React Native SDK for Jitsi Meet.",
-    "main": "index.tsx",
+    "main": "index.js",
     "license": "Apache-2.0",
     "author": "",
     "homepage": "https://jitsi.org",
@@ -91,6 +91,7 @@
     },
     "scripts": {
         "postinstall": "node sdk_instructions.js",
+        "generate-index": "tsc --project tsconfig-sdk-index.native.json",
         "prepare": "node prepare_sdk.js"
     },
     "bugs": {

--- a/react-native-sdk/tsconfig-sdk-index.native.json
+++ b/react-native-sdk/tsconfig-sdk-index.native.json
@@ -1,0 +1,7 @@
+{
+    "extends": "../tsconfig.native.json",
+    "include": ["index.tsx"],
+    "compilerOptions": {
+        "declaration": true
+    }
+}


### PR DESCRIPTION
Generate index.js and index.d.ts files from index.tsx and change entry point to index.js in react native sdk to prevent importing index.tsx when using the sdk, which will cause `tsc` type checking errors.