### PR TITLE
docs(README-GraceTech.md): add instructions for creating and using GraceTech Jitsi Meet SDK

### DIFF
--- a/README-GraceTech.md
+++ b/README-GraceTech.md
@@ -1,0 +1,45 @@
+# GraceTech Jitsi Meet SDK
+
+## Instructions
+
+### 1. Create new SDK version
+
+#### 1.1 Prepare
+The following steps need to be done only once.：
+1. Clone [gracetech-services/gt-jitsisdk](https://github.com/gracetech-services/gt-jitsisdk) Repo
+2. Get the local path directory of the above Repo, which will be used in subsequent steps.
+
+#### 1.2 Create 
+
+1. Navigate to `react-native-sdk` directory in this repo
+2. (Optional) Run `git switch <branch name>` to switch to the desired branch from which to create the new version
+3. Update version in `react-native-sdk/package.json` if not updated already
+4. Run `npm pack --pack-destination <path to gt-jitsisdk>/packages/`
+5. Rename the created `.tgz` file if desired and commit the file to GitHub
+
+Note: Only commit updated version in `package.json`, do not commit any other changes in this repo when creating a new SDK version.
+
+### 2. Use new SDK version in app
+
+1. Update `@jitsi/react-native-sdk` dependency in app `package.json` with the raw GitHub link to the desired `.tgz` file. Make sure the link references the file from a specific commit and does not reference a branch. For example: `https://github.com/gracetech-services/gt-jitsisdk/raw/314835fb95090505b4c24d422634eb85b988a086/packages/jitsi-react-native-sdk-0.0.0.tgz`
+
+### 3. Update Jitsi SDK for new Expo SDK version
+
+#### 3.1 Update Expo SDK
+1. In repo root, Run `npm install -D expo` to install Expo temporarily
+2. Run `npx expo install --fix` to fix React Native SDK peer dependency versions. Note: Updating `@types/*` or `typescript` packages may cause typing errors, do not update these packages if desired
+3. Run `npx expo-doctor` and fix issues
+4. Run `npm uninstall expo` to remove Expo
+
+#### 3.2 Update RNSDK dependencies
+1. Navigate to `react-native-sdk` directory in this repo, Run `node update_sdk_dependencies.js`
+2. Follow instructions above (1. Create new SDK version) to create new Jitsi SDK version
+
+### 4. Steps to regenerate index files
+
+@Max: Not yet verified
+
+1. Navigate to `react-native-sdk` directory
+2. Run `npm run generate-index`
+3. Delete all other generated files except `react-native-sdk/index.js` and `react-native-sdk/index.d.ts`
+4. Navigate to repo root and run `eslint --fix react-native-sdk/index.js` if needed to fix lint errors

--- a/react-native-sdk/update_sdk_dependencies.js
+++ b/react-native-sdk/update_sdk_dependencies.js
@@ -16,14 +16,14 @@ function mergeDependencyVersions() {
     // Updates SDK dependencies to match project dependencies.
     for (const key in SDKPackageJSON.dependencies) {
         if (SDKPackageJSON.dependencies.hasOwnProperty(key)) {
-            SDKPackageJSON.dependencies[key] = packageJSON.dependencies[key] || packageJSON.devDependencies[key];
+            SDKPackageJSON.dependencies[key] = addPatchVersion(packageJSON.dependencies[key] || packageJSON.devDependencies[key]);
         }
     }
 
     // Updates SDK peer dependencies.
     for (const key in packageJSON.dependencies) {
         if (SDKPackageJSON.peerDependencies.hasOwnProperty(key) && !skipDeps.includes(key)) {
-            SDKPackageJSON.peerDependencies[key] = packageJSON.dependencies[key];
+            SDKPackageJSON.peerDependencies[key] = addPatchVersion(packageJSON.dependencies[key])
         }
     }
 
@@ -47,6 +47,13 @@ function mergeDependencyVersions() {
     const data = JSON.stringify(SDKPackageJSON, null, 4);
 
     fs.writeFileSync('package.json', data);
+}
+
+// Check if it is a pure version number
+// if true, add `~` to be compatible with patch updates
+function addPatchVersion(ver) {
+    const isPureVer = /^\d+\.\d+\.\d+$/.test(ver);
+    return isPureVer ? `~${ver}`: ver;
 }
 
 mergeDependencyVersions();


### PR DESCRIPTION

Added detailed instructions to the README-GraceTech.md file, including steps for:
- Creating a new SDK version
- Using the new SDK version in an app
- Updating Jitsi SDK for a new Expo SDK version

Also updated the `update_sdk_dependencies.js` script to add patch version compatibility.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
