### PR TITLE
Fix(filmstrip): Show screen-sharing stream when videoStream is disabled

### DIFF
--- a/react/features/filmstrip/components/web/Thumbnail.tsx
+++ b/react/features/filmstrip/components/web/Thumbnail.tsx
@@ -1054,7 +1054,8 @@ class Thumbnail extends Component<IProps, IState> {
             videoEventListeners.onCanPlay = this._onCanPlay;
         }
 
-        const video = _videoTrack && <VideoTrack
+        const showVideo = _videoTrack && (_enableVideoStream || local || _videoTrack.videoType === 'desktop');
+        const video = showVideo && <VideoTrack
             className = { local ? videoTrackClassName : '' }
             eventHandlers = { videoEventListeners }
             id = { local ? 'localVideo_container' : `remoteVideo_${videoTrackId || ''}` }


### PR DESCRIPTION
When the `videoStream` button is disabled, it is intended to stop all video streams except for screen-sharing. However, the current implementation was hiding all video streams, including screen-sharing.

This change modifies the rendering logic in the `Thumbnail` component to always display the video if it is a screen-sharing stream, regardless of the `videoStream` button's state.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
