### PR TITLE
refactor(theme): Rename fishmeet theme variables to customizedUi 

### DIFF
--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -112,7 +112,7 @@ in `react/` after rsync. The key categories:
 #### Design tokens / palette
 `fishmeet/react/features/base/ui/Tokens.ts`
 Overrides `BaseTheme.palette` to inject fishmeet brand colors
-(`fishMeetUiBackground`, `fishMeetMainColor02`, `fishMeetText03`, etc.).
+(`customizedUiBackground`, `customizedUiMainColor02`, `customizedUiText03`, etc.).
 This is the **single source of truth** for all brand colors — reference palette
 tokens in stylesheets rather than hardcoding hex values.
 
@@ -135,7 +135,7 @@ fishmeet-specific values. Changed properties are annotated with
 #### Constants overrides
 `fishmeet/react/features/participants-pane/constants.tsx`
 Replaces `AudioStateIcons` and `VideoStateIcons` with fishmeet circular icon
-containers (37×37 px, `fishMeetMainColor02` background).
+containers (37×37 px, `customizedUiMainColor02` background).
 
 #### Navigation overrides
 | Override file | What it customizes |

--- a/fishmeet/fishmeet-config.js
+++ b/fishmeet/fishmeet-config.js
@@ -31,7 +31,16 @@ config.customTheme = {
         action01: '#FE9C75',
         action01Hover: '#E88B64',
         // Override warning colors (used for raised hand)
-        warning02: '#FE9C75'
+        warning02: '#FE9C75',
+
+        customizedUiBackground: '#42434F',
+        customizedUiSecBackground: '#656876',
+        customizedUiMainColor01: '#FE9C75',
+        customizedUiMainColor02: '#C8D7EC',
+        customizedUiAction01: '#E7EEF2',
+        customizedUiText01: '#424350',
+        customizedUiText02: '#28262C',
+        customizedUiText03: '#33333F',
     }
 };
 

--- a/fishmeet/react/features/base/react/components/native/styles.ts
+++ b/fishmeet/react/features/base/react/components/native/styles.ts
@@ -169,9 +169,9 @@ export default {
             color: 'transparent',
             containerStyle: {
                 ...iconFishmeetButtonContainer,
-                backgroundColor: BaseTheme.palette.fishMeetMainColor01
+                backgroundColor: BaseTheme.palette.customizedUiMainColor01
             },
-            underlayColor: BaseTheme.palette.fishMeetMainColor01,
+            underlayColor: BaseTheme.palette.customizedUiMainColor01,
             disabledColor: 'transparent',
             disabledContainerStyle: {
                 ...iconFishmeetButtonContainer,
@@ -179,12 +179,12 @@ export default {
             }
         },
         [BUTTON_TYPES.SECONDARY]: {
-            color: BaseTheme.palette.fishMeetText01,
+            color: BaseTheme.palette.customizedUiText01,
             containerStyle: {
                 ...iconFishmeetButtonContainer,
-                backgroundColor: BaseTheme.palette.fishMeetMainColor01
+                backgroundColor: BaseTheme.palette.customizedUiMainColor01
             },
-            underlayColor: BaseTheme.palette.fishMeetMainColor01,
+            underlayColor: BaseTheme.palette.customizedUiMainColor01,
             disabledColor: 'transparent',
             disabledContainerStyle: {
                 ...iconFishmeetButtonContainer,
@@ -195,9 +195,9 @@ export default {
             color: 'transparent',
             containerStyle: {
                 ...iconFishmeetButtonContainer,
-                backgroundColor: BaseTheme.palette.fishMeetMainColor02
+                backgroundColor: BaseTheme.palette.customizedUiMainColor02
             },
-            underlayColor: BaseTheme.palette.fishMeetMainColor02,
+            underlayColor: BaseTheme.palette.customizedUiMainColor02,
             disabledColor: 'transparent',
             disabledContainerStyle: {
                 ...iconFishmeetButtonContainer,

--- a/fishmeet/react/features/base/ui/Tokens.ts
+++ b/fishmeet/react/features/base/ui/Tokens.ts
@@ -6,14 +6,19 @@ export const colorMap = {
     //  - JitsiMeetView.m
     //  - JitsiMeetView.java
     uiBackground: 'surface01',
-    fishMeetUiBackground: '#42434F',
-    fishMeetUiSecBackground: '#656876',
-    fishMeetMainColor01: '#FE9C75',
-    fishMeetMainColor02: '#C8D7EC',
-    fishMeetAction01: '#E7EEF2',
-    fishMeetText01: '#424350',
-    fishMeetText02: '#28262C',
-    fishMeetText03: '#33333F',
+
+    // GraceTech Customization design token
+    // Do not hardcode the colors:
+    // define them at type GraceTechCustomizedPalette: react/features/base/ui/functions.web.ts:9
+    // config them at fishmeet-config.js -》 config.customTheme
+    customizedUiBackground: 'customizedUiBackground',
+    customizedUiSecBackground: 'customizedUiSecBackground',
+    customizedUiMainColor01: 'customizedUiMainColor01',
+    customizedUiMainColor02: 'customizedUiMainColor02',
+    customizedUiAction01: 'customizedUiAction01',
+    customizedUiText01: 'customizedUiText01',
+    customizedUiText02: 'customizedUiText02',
+    customizedUiText03: 'customizedUiText03',
 
     // Container backgrounds
     ui01: 'surface02',

--- a/fishmeet/react/features/base/ui/components/native/buttonStyles.ts
+++ b/fishmeet/react/features/base/ui/components/native/buttonStyles.ts
@@ -20,7 +20,7 @@ const buttonLabel = {
 const pillButtonLabel = {
     ...buttonLabel,
     textTransform: 'capitalize',
-    color: BaseTheme.palette.fishMeetText01
+    color: BaseTheme.palette.customizedUiText01
 };
 
 export default {
@@ -87,15 +87,15 @@ export default {
     // per-type config: label style and background color for NativePaperButton
     buttonTypeConfig: {
         [BUTTON_TYPES.PRIMARY]: {
-            color: BaseTheme.palette.fishMeetMainColor01,
+            color: BaseTheme.palette.customizedUiMainColor01,
             labelStyle: pillButtonLabel
         },
         [BUTTON_TYPES.SECONDARY]: {
-            color: BaseTheme.palette.fishMeetAction01,
+            color: BaseTheme.palette.customizedUiAction01,
             labelStyle: pillButtonLabel
         },
         [BUTTON_TYPES.TERTIARY]: {
-            color: BaseTheme.palette.fishMeetMainColor02,
+            color: BaseTheme.palette.customizedUiMainColor02,
             labelStyle: pillButtonLabel
         },
         [BUTTON_TYPES.DESTRUCTIVE]: {

--- a/fishmeet/react/features/chat/components/native/styles.ts
+++ b/fishmeet/react/features/chat/components/native/styles.ts
@@ -101,7 +101,7 @@ export default {
 
     chatMessage: {
         ...BaseTheme.typography.bodyShortRegular,
-        color: BaseTheme.palette.fishMeetText02 // fishmeet: was text01
+        color: BaseTheme.palette.customizedUiText02 // fishmeet: was text01
     },
 
     /**
@@ -155,8 +155,8 @@ export default {
 
     // fishmeet: input field styling
     customInput: {
-        backgroundColor: BaseTheme.palette.fishMeetUiBackground,
-        borderColor: BaseTheme.palette.fishMeetMainColor02,
+        backgroundColor: BaseTheme.palette.customizedUiBackground,
+        borderColor: BaseTheme.palette.customizedUiMainColor02,
         borderRadius: 30,
         borderWidth: 1
     },
@@ -210,7 +210,7 @@ export default {
      * Text node for the timestamp.
      */
     timeText: {
-        color: BaseTheme.palette.fishMeetMainColor02, // fishmeet: was text03
+        color: BaseTheme.palette.customizedUiMainColor02, // fishmeet: was text03
         fontSize: 13
     },
 
@@ -222,7 +222,7 @@ export default {
 
     // fishmeet: use brand background instead of ui01
     chatContainer: {
-        backgroundColor: BaseTheme.palette.fishMeetUiBackground,
+        backgroundColor: BaseTheme.palette.customizedUiBackground,
         flex: 1
     },
 
@@ -258,11 +258,11 @@ export default {
 
     senderDisplayName: {
         ...BaseTheme.typography.bodyShortBold,
-        color: BaseTheme.palette.fishMeetText02 // fishmeet: was text02
+        color: BaseTheme.palette.customizedUiText02 // fishmeet: was text02
     },
 
     localMessageBubble: {
-        backgroundColor: BaseTheme.palette.fishMeetMainColor02, // fishmeet: was ui04
+        backgroundColor: BaseTheme.palette.customizedUiMainColor02, // fishmeet: was ui04
         borderTopRightRadius: 0
     },
 

--- a/fishmeet/react/features/conference/components/native/styles.ts
+++ b/fishmeet/react/features/conference/components/native/styles.ts
@@ -39,7 +39,7 @@ export default {
      */
     conference: {
         alignSelf: 'stretch',
-        backgroundColor: BaseTheme.palette.fishMeetUiBackground, // fishmeet: was uiBackground
+        backgroundColor: BaseTheme.palette.customizedUiBackground, // fishmeet: was uiBackground
         flex: 1
     },
 
@@ -112,7 +112,7 @@ export default {
 
     titleBarSafeViewColor: {
         ...titleBarSafeView,
-        backgroundColor: BaseTheme.palette.fishMeetUiBackground // fishmeet: was uiBackground
+        backgroundColor: BaseTheme.palette.customizedUiBackground // fishmeet: was uiBackground
     },
 
     titleBarSafeViewTransparent: {

--- a/fishmeet/react/features/dynamic-branding/actions.any.ts
+++ b/fishmeet/react/features/dynamic-branding/actions.any.ts
@@ -1,0 +1,88 @@
+import { IStore } from '../app/types';
+import { doGetJSON } from '../base/util/httpUtils';
+
+import {
+    SET_DYNAMIC_BRANDING_DATA,
+    SET_DYNAMIC_BRANDING_FAILED,
+    SET_DYNAMIC_BRANDING_READY
+} from './actionTypes';
+import { getDynamicBrandingUrl } from './functions.any';
+import logger from './logger';
+
+
+/**
+ * Fetches custom branding data.
+ * If there is no data or the request fails, sets the `customizationReady` flag
+ * so the defaults can be displayed.
+ *
+ * @returns {Function}
+ */
+export function fetchCustomBrandingData() {
+    return async function(dispatch: IStore['dispatch'], getState: IStore['getState']) {
+        const state = getState();
+        const { customizationReady } = state['features/dynamic-branding'];
+
+        if (!customizationReady) {
+            const url = await getDynamicBrandingUrl(state);
+            const config
+                = navigator.product === 'ReactNative'
+                    ? state['features/base/config']
+                    : window.config;
+
+            if (url) {
+                try {
+                    const res = await doGetJSON(url);
+
+                    return dispatch(setDynamicBrandingData(res));
+                } catch (err) {
+                    logger.error('Error fetching branding data', err);
+
+                    return dispatch(setDynamicBrandingFailed());
+                }
+            }
+
+            if (config?.customTheme) {
+                return dispatch(setDynamicBrandingData({
+                    customTheme: config.customTheme
+                }));
+            }
+
+            dispatch(setDynamicBrandingReady());
+        }
+    };
+}
+
+/**
+ * Action used to set the user customizations.
+ *
+ * @param {Object} value - The custom data to be set.
+ * @returns {Object}
+ */
+export function setDynamicBrandingData(value: Object) {
+    return {
+        type: SET_DYNAMIC_BRANDING_DATA,
+        value
+    };
+}
+
+/**
+ * Action used to signal the branding elements are ready to be displayed.
+ *
+ * @returns {Object}
+ */
+export function setDynamicBrandingReady() {
+    return {
+        type: SET_DYNAMIC_BRANDING_READY
+    };
+}
+
+/**
+ * Action used to signal the branding request failed.
+ *
+ * @returns {Object}
+ */
+export function setDynamicBrandingFailed() {
+    return {
+        type: SET_DYNAMIC_BRANDING_FAILED
+    };
+}

--- a/fishmeet/react/features/mobile/navigation/components/conference/components/fishMeetNavigationStyles.ts
+++ b/fishmeet/react/features/mobile/navigation/components/conference/components/fishMeetNavigationStyles.ts
@@ -2,7 +2,7 @@ import BaseTheme from '../../../../../base/ui/components/BaseTheme.native';
 
 export const styleHeader = {
     viewStyle: {
-        backgroundColor: BaseTheme.palette.fishMeetUiBackground,
+        backgroundColor: BaseTheme.palette.customizedUiBackground,
         height: 60,
         borderTopLeftRadius: 30,
         borderTopRightRadius: 30,

--- a/fishmeet/react/features/mobile/navigation/screenOptions.ts
+++ b/fishmeet/react/features/mobile/navigation/screenOptions.ts
@@ -67,10 +67,10 @@ export const visitorsScreenOptions = fullScreenOptions;
 export const chatTabBarOptions = {
     swipeEnabled: false,
     tabBarIndicatorStyle: {
-        backgroundColor: BaseTheme.palette.fishMeetMainColor02
+        backgroundColor: BaseTheme.palette.customizedUiMainColor02
     },
     tabBarStyle: {
-        backgroundColor: BaseTheme.palette.fishMeetUiBackground,
+        backgroundColor: BaseTheme.palette.customizedUiBackground,
         borderBottomColor: '#C8D7EC80',
         borderBottomWidth: 0.4
     }

--- a/fishmeet/react/features/participants-pane/components/native/styles.ts
+++ b/fishmeet/react/features/participants-pane/components/native/styles.ts
@@ -193,7 +193,7 @@ export default {
     },
 
     participantsPaneContainer: {
-        backgroundColor: BaseTheme.palette.fishMeetUiBackground, // fishmeet: was ui01
+        backgroundColor: BaseTheme.palette.customizedUiBackground, // fishmeet: was ui01
         flex: 1,
         flexDirection: 'column',
         paddingVertical: BaseTheme.spacing[2]
@@ -284,7 +284,7 @@ export default {
     centerInput: {
         paddingRight: BaseTheme.spacing[3],
         textAlign: 'left', // fishmeet: was 'center'
-        backgroundColor: BaseTheme.palette.fishMeetUiBackground,
+        backgroundColor: BaseTheme.palette.customizedUiBackground,
         borderColor: '#fff',
         borderWidth: 0.5,
         borderRadius: 30

--- a/fishmeet/react/features/participants-pane/constants.native.tsx
+++ b/fishmeet/react/features/participants-pane/constants.native.tsx
@@ -63,7 +63,7 @@ export const QUICK_ACTION_BUTTON: {
 
 // fishmeet: icon state style for circular icon containers
 const iconState: ViewStyle = {
-    backgroundColor: '#C8D7EC', // fishMeetMainColor02
+    backgroundColor: '#C8D7EC', // customizedUiMainColor02
     height: 37,
     width: 37,
     borderRadius: 20,

--- a/fishmeet/react/features/polls/components/native/styles.ts
+++ b/fishmeet/react/features/polls/components/native/styles.ts
@@ -135,8 +135,8 @@ export const pollsStyles = createStyleSheet({
     },
 
     pollItemContainer: {
-        backgroundColor: BaseTheme.palette.fishMeetText03,
-        borderColor: BaseTheme.palette.fishMeetText03,
+        backgroundColor: BaseTheme.palette.customizedUiText03,
+        borderColor: BaseTheme.palette.customizedUiText03,
         borderRadius: 30,
         borderWidth: 1,
         padding: BaseTheme.spacing[2],
@@ -144,10 +144,10 @@ export const pollsStyles = createStyleSheet({
     },
 
     switchProps: {
-        thumbColor: BaseTheme.palette.fishMeetText03,
+        thumbColor: BaseTheme.palette.customizedUiText03,
         // @ts-ignore
         trackColor: {
-            true: BaseTheme.palette.fishMeetMainColor02,
+            true: BaseTheme.palette.customizedUiMainColor02,
             false: '#C8D7EC80'
         }
     },
@@ -229,7 +229,7 @@ export const pollsStyles = createStyleSheet({
     },
 
     pollPaneContainer: {
-        backgroundColor: BaseTheme.palette.fishMeetUiBackground, // fishmeet: was ui01
+        backgroundColor: BaseTheme.palette.customizedUiBackground, // fishmeet: was ui01
         flex: 1
     },
 

--- a/fishmeet/react/features/toolbox/components/native/fishMeetStyles.ts
+++ b/fishmeet/react/features/toolbox/components/native/fishMeetStyles.ts
@@ -36,7 +36,7 @@ export const fishMeetToolbarButtonIcon = {
 const fishMeetStyles = {
     fishMeetToolbox: {
         alignItems: 'center',
-        backgroundColor: BaseTheme.palette.fishMeetUiBackground,
+        backgroundColor: BaseTheme.palette.customizedUiBackground,
         borderTopLeftRadius: 3,
         borderTopRightRadius: 3,
         flexDirection: 'row',
@@ -46,7 +46,7 @@ const fishMeetStyles = {
 
     fishMeetToolboxContainer: {
         flexDirection: 'row',
-        backgroundColor: BaseTheme.palette.fishMeetMainColor02,
+        backgroundColor: BaseTheme.palette.customizedUiMainColor02,
         borderRadius: 30,
         paddingLeft: 8, // fishmeet: was 10 — reduced to fit 5 buttons on 375pt screens
         paddingRight: 8, // fishmeet: was 10 — reduced to fit 5 buttons on 375pt screens

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -247,6 +247,7 @@ export interface IConfig {
     };
     corsAvatarURLs?: Array<string>;
     customParticipantMenuButtons?: Array<{ icon: string; id: string; text: string; }>;
+    customTheme?: any; // support custom theme from config.js
     customToolbarButtons?: Array<{ backgroundColor?: string; icon: string; id: string; text: string; }>;
     deeplinking?: IDeeplinkingConfig;
     defaultLanguage?: string;

--- a/react/features/base/ui/components/web/BaseDialog.tsx
+++ b/react/features/base/ui/components/web/BaseDialog.tsx
@@ -15,7 +15,7 @@ const useStyles = makeStyles()(theme => {
             width: '100%',
             height: '100%',
             position: 'fixed',
-            color: theme.palette.fishMeetText01, // fishmeet: was theme.palette.text01,
+            color: theme.palette.customizedUiText01, // fishmeet: was theme.palette.text01,
             ...withPixelLineHeight(theme.typography.bodyLongRegular),
             top: 0,
             left: 0,
@@ -55,7 +55,7 @@ const useStyles = makeStyles()(theme => {
         },
 
         modal: {
-            backgroundColor: theme.palette.fishMeetMainColor02, // fishmeet: was theme.palette.ui01,
+            backgroundColor: theme.palette.customizedUiMainColor02, // fishmeet: was theme.palette.ui01,
             border: `1px solid ${theme.palette.ui03}`,
             boxShadow: '0px 4px 25px 4px rgba(20, 20, 20, 0.6)',
             borderRadius: `${theme.shape.borderRadius}px`,

--- a/react/features/base/ui/components/web/ContextMenu.tsx
+++ b/react/features/base/ui/components/web/ContextMenu.tsx
@@ -134,11 +134,11 @@ const MAX_HEIGHT = 400;
 const useStyles = makeStyles()(theme => {
     return {
         contextMenu: {
-            backgroundColor: theme.palette.fishMeetMainColor02, // fishmeet: was ui01
-            border: `1px solid ${theme.palette.fishMeetMainColor02}`, // fishmeet: was ui04
+            backgroundColor: theme.palette.customizedUiMainColor02, // fishmeet: was ui01
+            border: `1px solid ${theme.palette.customizedUiMainColor02}`, // fishmeet: was ui04
             borderRadius: `${Number(theme.shape.borderRadius)}px`,
             boxShadow: '0px 1px 2px rgba(41, 41, 41, 0.25)',
-            color: theme.palette.fishMeetText03, // fishmeet: was text01
+            color: theme.palette.customizedUiText03, // fishmeet: was text01
             ...withPixelLineHeight(theme.typography.bodyShortRegular),
             marginTop: '48px',
             position: 'absolute',

--- a/react/features/base/ui/components/web/ContextMenuItem.tsx
+++ b/react/features/base/ui/components/web/ContextMenuItem.tsx
@@ -123,11 +123,11 @@ const useStyles = makeStyles()(theme => {
             },
 
             '&:hover': {
-                backgroundColor: theme.palette.fishMeetAction01 // fishmeet: was ui02
+                backgroundColor: theme.palette.customizedUiAction01 // fishmeet: was ui02
             },
 
             '&:active': {
-                backgroundColor: theme.palette.fishMeetAction01 // fishmeet: was ui03
+                backgroundColor: theme.palette.customizedUiAction01 // fishmeet: was ui03
             },
 
             '&.focus-visible': {
@@ -138,7 +138,7 @@ const useStyles = makeStyles()(theme => {
         selected: {
             borderLeft: `3px solid ${theme.palette.action01Hover}`,
             paddingLeft: '13px',
-            backgroundColor: theme.palette.fishMeetAction01 // fishmeet: was ui02
+            backgroundColor: theme.palette.customizedUiAction01 // fishmeet: was ui02
         },
 
         contextMenuItemDisabled: {
@@ -147,7 +147,7 @@ const useStyles = makeStyles()(theme => {
 
         contextMenuItemIconDisabled: {
             '& svg': {
-                fill: `${theme.palette.fishMeetText01} !important`
+                fill: `${theme.palette.customizedUiText01} !important`
             }
         },
 
@@ -175,7 +175,7 @@ const useStyles = makeStyles()(theme => {
 
         text: {
             ...withPixelLineHeight(theme.typography.bodyShortRegular),
-            color: theme.palette.fishMeetText01 // fishmeet: was icon01
+            color: theme.palette.customizedUiText01 // fishmeet: was icon01
         },
 
         drawerText: {

--- a/react/features/base/ui/components/web/Dialog.tsx
+++ b/react/features/base/ui/components/web/Dialog.tsx
@@ -25,7 +25,7 @@ const useStyles = makeStyles()(theme => {
         },
 
         title: {
-            color: theme.palette.fishMeetText01, // fishmeet: was theme.palette.text01,
+            color: theme.palette.customizedUiText01, // fishmeet: was theme.palette.text01,
             ...withPixelLineHeight(theme.typography.heading5),
             margin: 0,
             padding: 0

--- a/react/features/base/ui/components/web/Input.tsx
+++ b/react/features/base/ui/components/web/Input.tsx
@@ -50,7 +50,7 @@ const useStyles = makeStyles()(theme => {
         },
 
         label: {
-            color: theme.palette.fishMeetText01, // fishmeet: was text01
+            color: theme.palette.customizedUiText01, // fishmeet: was text01
             ...withPixelLineHeight(theme.typography.bodyShortRegular),
             marginBottom: theme.spacing(2),
 
@@ -65,8 +65,8 @@ const useStyles = makeStyles()(theme => {
         },
 
         input: {
-            backgroundColor: theme.palette.fishMeetUiSecBackground, // fishmeet: was ui03
-            background: theme.palette.fishMeetUiSecBackground, // fishmeet: was ui03
+            backgroundColor: theme.palette.customizedUiSecBackground, // fishmeet: was ui03
+            background: theme.palette.customizedUiSecBackground, // fishmeet: was ui03
             boxShadow: `0px 0px 0px 2px ${theme.palette.focus01}`, // fishmeet: was nil
             color: theme.palette.text01,
             ...withPixelLineHeight(theme.typography.bodyShortRegular),

--- a/react/features/base/ui/functions.web.ts
+++ b/react/features/base/ui/functions.web.ts
@@ -19,7 +19,7 @@ type GraceTechCustomizedPalette = {
 
 declare module '@mui/material/styles' {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface Palette extends Palette1, GraceTechCustomizedPalette {} // fishmeet: add IFishMeetCustomPalette
+    interface Palette extends Palette1, GraceTechCustomizedPalette {} // fishmeet: add GraceTechCustomizedPalette
 
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
     interface TypographyVariants extends ITypography {}

--- a/react/features/base/ui/functions.web.ts
+++ b/react/features/base/ui/functions.web.ts
@@ -5,21 +5,21 @@ import { ITypography, IPalette as Palette1 } from '../ui/types';
 
 import { createColorTokens, createTypographyTokens } from './utils';
 
-/* fishmeet custom palette */
-type IFishMeetCustomPalette = {
-    fishMeetAction01: string;
-    fishMeetMainColor01: string;
-    fishMeetMainColor02: string;
-    fishMeetText01: string;
-    fishMeetText02: string;
-    fishMeetText03: string;
-    fishMeetUiBackground: string;
-    fishMeetUiSecBackground: string;
+/* GraceTech custom palette */
+type GraceTechCustomizedPalette = {
+    customizedUiAction01: string;
+    customizedUiBackground: string;
+    customizedUiMainColor01: string;
+    customizedUiMainColor02: string;
+    customizedUiSecBackground: string;
+    customizedUiText01: string;
+    customizedUiText02: string;
+    customizedUiText03: string;
 };
 
 declare module '@mui/material/styles' {
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface Palette extends Palette1, IFishMeetCustomPalette {} // fishmeet: add IFishMeetCustomPalette
+    interface Palette extends Palette1, GraceTechCustomizedPalette {} // fishmeet: add IFishMeetCustomPalette
 
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
     interface TypographyVariants extends ITypography {}

--- a/react/features/participants-pane/components/web/ParticipantsPane.tsx
+++ b/react/features/participants-pane/components/web/ParticipantsPane.tsx
@@ -48,7 +48,7 @@ interface IStylesProps {
 const useStyles = makeStyles<IStylesProps>()((theme, { isChatOpen }) => {
     return {
         participantsPane: {
-            backgroundColor: theme.palette.fishMeetUiBackground, // fishmeet: was ui01
+            backgroundColor: theme.palette.customizedUiBackground, // fishmeet: was ui01
             flexShrink: 0,
             position: 'relative',
             transition: 'width .16s ease-in-out',

--- a/react/features/toolbox/components/web/Drawer.tsx
+++ b/react/features/toolbox/components/web/Drawer.tsx
@@ -44,7 +44,7 @@ const useStyles = makeStyles()(theme => {
         },
 
         drawer: {
-            backgroundColor: theme.palette.fishMeetMainColor02, // fishmeet was: ui01
+            backgroundColor: theme.palette.customizedUiMainColor02, // fishmeet was: ui01
             maxHeight: `calc(${DRAWER_MAX_HEIGHT})`,
             borderRadius: '24px 24px 0 0',
             overflowY: 'auto',

--- a/react/features/video-menu/components/web/ParticipantContextMenu.tsx
+++ b/react/features/video-menu/components/web/ParticipantContextMenu.tsx
@@ -107,7 +107,7 @@ interface IProps {
 const useStyles = makeStyles()(theme => {
     return {
         text: {
-            color: theme.palette.fishMeetText01, // fishmeet: was text01
+            color: theme.palette.customizedUiText01, // fishmeet: was text01
             padding: '10px 16px',
             height: '40px',
             overflow: 'hidden',


### PR DESCRIPTION
## Main change

1. Standardize the configuration items of the custom theme to the naming convention of `customizedUiXxx`.
2. Support configuring `customTheme` in `config.js` instead of hard-coding it in `token.ts`.