### PR TITLE
feat(Notification): hide entry notification when user come back from breakouRoom

### DIFF
--- a/fishmeet/react/features/notifications/actionTypes.ts
+++ b/fishmeet/react/features/notifications/actionTypes.ts
@@ -49,8 +49,8 @@ export const SET_NOTIFICATIONS_ENABLED = 'SET_NOTIFICATIONS_ENABLED';
  * should be updated.
  *
  * {
- *     type: SET_BREAKOUT_ROOM_PARTICIPANT,
- *     participant: Object
+ *     type: SET_BREAKOUT_ROOM_PARTICIPANTS,
+ *     participants: IRoom['participants']
  * }
  */
-export const SET_BREAKOUT_ROOM_PARTICIPANT = 'SET_BREAKOUT_ROOM_PARTICIPANT';
+export const SET_BREAKOUT_ROOM_PARTICIPANTS = 'SET_BREAKOUT_ROOM_PARTICIPANTS';

--- a/fishmeet/react/features/notifications/actionTypes.ts
+++ b/fishmeet/react/features/notifications/actionTypes.ts
@@ -1,0 +1,56 @@
+/**
+ * The type of (redux) action which signals that all the stored notifications
+ * need to be cleared.
+ *
+ * {
+ *     type: CLEAR_NOTIFICATIONS
+ * }
+ */
+export const CLEAR_NOTIFICATIONS = 'CLEAR_NOTIFICATIONS';
+
+/**
+ * The type of (redux) action which signals that a specific notification should
+ * not be displayed anymore.
+ *
+ * {
+ *     type: HIDE_NOTIFICATION,
+ *     uid: string
+ * }
+ */
+export const HIDE_NOTIFICATION = 'HIDE_NOTIFICATION';
+
+/**
+ * The type of (redux) action which signals that a notification component should
+ * be displayed.
+ *
+ * {
+ *     type: SHOW_NOTIFICATION,
+ *     component: ReactComponent,
+ *     props: Object,
+ *     timeout: number,
+ *     uid: string
+ * }
+ */
+export const SHOW_NOTIFICATION = 'SHOW_NOTIFICATION';
+
+/**
+ * The type of (redux) action which signals that notifications should not
+ * display.
+ *
+ * {
+ *     type: SET_NOTIFICATIONS_ENABLED,
+ *     enabled: Boolean
+ * }
+ */
+export const SET_NOTIFICATIONS_ENABLED = 'SET_NOTIFICATIONS_ENABLED';
+
+/**
+ * The type of (redux) action which signals that the breakout room participant
+ * should be updated.
+ *
+ * {
+ *     type: SET_BREAKOUT_ROOM_PARTICIPANT,
+ *     participant: Object
+ * }
+ */
+export const SET_BREAKOUT_ROOM_PARTICIPANT = 'SET_BREAKOUT_ROOM_PARTICIPANT';

--- a/fishmeet/react/features/notifications/actions.ts
+++ b/fishmeet/react/features/notifications/actions.ts
@@ -105,8 +105,6 @@ export function setNotificationsEnabled(enabled: boolean) {
  * }}
  */
 export function setBreakoutRoomParticipant(participants: IRoom['participants']) {
-    console.log('[GTS] notifications setBreakoutRoomParticipant:', participants);
-
     return {
         type: SET_BREAKOUT_ROOM_PARTICIPANT,
         participants

--- a/fishmeet/react/features/notifications/actions.ts
+++ b/fishmeet/react/features/notifications/actions.ts
@@ -10,7 +10,7 @@ import { IRoom } from '../breakout-rooms/types';
 import {
     CLEAR_NOTIFICATIONS,
     HIDE_NOTIFICATION,
-    SET_BREAKOUT_ROOM_PARTICIPANT,
+    SET_BREAKOUT_ROOM_PARTICIPANTS,
     SET_NOTIFICATIONS_ENABLED,
     SHOW_NOTIFICATION
 } from './actionTypes';
@@ -106,7 +106,7 @@ export function setNotificationsEnabled(enabled: boolean) {
  */
 export function setBreakoutRoomParticipant(participants: IRoom['participants']) {
     return {
-        type: SET_BREAKOUT_ROOM_PARTICIPANT,
+        type: SET_BREAKOUT_ROOM_PARTICIPANTS,
         participants
     };
 }

--- a/fishmeet/react/features/notifications/actions.ts
+++ b/fishmeet/react/features/notifications/actions.ts
@@ -1,0 +1,368 @@
+import { throttle } from 'lodash-es';
+
+import { IStore } from '../app/types';
+import { IConfig } from '../base/config/configType';
+import { NOTIFICATIONS_ENABLED } from '../base/flags/constants';
+import { getFeatureFlag } from '../base/flags/functions';
+import { getParticipantCount } from '../base/participants/functions';
+import { IRoom } from '../breakout-rooms/types';
+
+import {
+    CLEAR_NOTIFICATIONS,
+    HIDE_NOTIFICATION,
+    SET_BREAKOUT_ROOM_PARTICIPANT,
+    SET_NOTIFICATIONS_ENABLED,
+    SHOW_NOTIFICATION
+} from './actionTypes';
+import {
+    NOTIFICATION_ICON,
+    NOTIFICATION_TIMEOUT,
+    NOTIFICATION_TIMEOUT_TYPE,
+    NOTIFICATION_TYPE,
+    SILENT_JOIN_THRESHOLD,
+    SILENT_LEFT_THRESHOLD
+} from './constants';
+import { INotificationProps } from './types';
+
+
+/**
+ * Function that returns notification timeout value based on notification timeout type.
+ *
+ * @param {string} type - Notification type.
+ * @param {Object} notificationTimeouts - Config notification timeouts.
+ * @returns {number}
+ */
+function getNotificationTimeout(type?: string, notificationTimeouts?: IConfig['notificationTimeouts']) {
+    if (type === NOTIFICATION_TIMEOUT_TYPE.SHORT) {
+        return notificationTimeouts?.short ?? NOTIFICATION_TIMEOUT.SHORT;
+    } else if (type === NOTIFICATION_TIMEOUT_TYPE.MEDIUM) {
+        return notificationTimeouts?.medium ?? NOTIFICATION_TIMEOUT.MEDIUM;
+    } else if (type === NOTIFICATION_TIMEOUT_TYPE.LONG) {
+        return notificationTimeouts?.long ?? NOTIFICATION_TIMEOUT.LONG;
+    } else if (type === NOTIFICATION_TIMEOUT_TYPE.EXTRA_LONG) {
+        return notificationTimeouts?.extraLong ?? NOTIFICATION_TIMEOUT.EXTRA_LONG;
+    } else if (type === NOTIFICATION_TIMEOUT_TYPE.STICKY) {
+        return notificationTimeouts?.sticky ?? NOTIFICATION_TIMEOUT.STICKY;
+    }
+
+    return 0;
+}
+
+/**
+ * Clears (removes) all the notifications.
+ *
+ * @returns {{
+ *     type: CLEAR_NOTIFICATIONS
+ * }}
+ */
+export function clearNotifications() {
+    return {
+        type: CLEAR_NOTIFICATIONS
+    };
+}
+
+/**
+ * Removes the notification with the passed in id.
+ *
+ * @param {string} uid - The unique identifier for the notification to be
+ * removed.
+ * @returns {{
+ *     type: HIDE_NOTIFICATION,
+ *     uid: string
+ * }}
+ */
+export function hideNotification(uid: string) {
+    return {
+        type: HIDE_NOTIFICATION,
+        uid
+    };
+}
+
+/**
+ * Stops notifications from being displayed.
+ *
+ * @param {boolean} enabled - Whether or not notifications should display.
+ * @returns {{
+ *     type: SET_NOTIFICATIONS_ENABLED,
+ *     enabled: boolean
+ * }}
+ */
+export function setNotificationsEnabled(enabled: boolean) {
+    return {
+        type: SET_NOTIFICATIONS_ENABLED,
+        enabled
+    };
+}
+
+/**
+ * The type of (redux) action which signals that the breakout room participant
+ * should be updated.
+ *
+ * @param {Object} participants - The breakout room participant.
+ * @returns {{
+ *     type: SET_BREAKOUT_ROOM_PARTICIPANT,
+ *     participant: Object
+ * }}
+ */
+export function setBreakoutRoomParticipant(participants: IRoom['participants']) {
+    console.log('[GTS] notifications setBreakoutRoomParticipant:', participants);
+
+    return {
+        type: SET_BREAKOUT_ROOM_PARTICIPANT,
+        participants
+    };
+}
+
+/**
+ * Queues an error notification for display.
+ *
+ * @param {Object} props - The props needed to show the notification component.
+ * @param {string} type - Notification type.
+ * @returns {Object}
+ */
+export function showErrorNotification(props: INotificationProps, type = NOTIFICATION_TIMEOUT_TYPE.STICKY) {
+    return showNotification({
+        ...props,
+        appearance: NOTIFICATION_TYPE.ERROR
+    }, type);
+}
+
+/**
+ * Queues a success notification for display.
+ *
+ * @param {Object} props - The props needed to show the notification component.
+ * @param {string} type - Notification type.
+ * @returns {Object}
+ */
+export function showSuccessNotification(props: INotificationProps, type?: string) {
+    return showNotification({
+        ...props,
+        appearance: NOTIFICATION_TYPE.SUCCESS
+    }, type);
+}
+
+/**
+ * Queues a notification for display.
+ *
+ * @param {Object} props - The props needed to show the notification component.
+ * @param {string} type - Timeout type.
+ * @returns {Function}
+ */
+export function showNotification(props: INotificationProps = {}, type?: string) {
+    return function(dispatch: IStore['dispatch'], getState: IStore['getState']) {
+        const { disabledNotifications = [], notifications, notificationTimeouts } = getState()['features/base/config'];
+        const enabledFlag = getFeatureFlag(getState(), NOTIFICATIONS_ENABLED, true);
+
+        const { descriptionKey, titleKey } = props;
+
+        const shouldDisplay = enabledFlag
+            && !(disabledNotifications.includes(descriptionKey ?? '')
+                || disabledNotifications.includes(titleKey ?? ''))
+            && (!notifications
+                || notifications.includes(descriptionKey ?? '')
+                || notifications.includes(titleKey ?? ''));
+
+        if (typeof APP !== 'undefined') {
+            APP.API.notifyNotificationTriggered(titleKey, descriptionKey);
+        }
+
+        if (shouldDisplay) {
+            return dispatch({
+                type: SHOW_NOTIFICATION,
+                props,
+                timeout: getNotificationTimeout(type, notificationTimeouts),
+                uid: props.uid || Date.now().toString()
+            });
+        }
+    };
+}
+
+/**
+ * Queues a warning notification for display.
+ *
+ * @param {Object} props - The props needed to show the notification component.
+ * @param {string} type - Notification type.
+ * @returns {Object}
+ */
+export function showWarningNotification(props: INotificationProps, type?: string) {
+
+    return showNotification({
+        ...props,
+        appearance: NOTIFICATION_TYPE.WARNING
+    }, type);
+}
+
+/**
+ * Queues a message notification for display.
+ *
+ * @param {Object} props - The props needed to show the notification component.
+ * @param {string} type - Notification type.
+ * @returns {Object}
+ */
+export function showMessageNotification(props: INotificationProps, type?: string) {
+    return showNotification({
+        ...props,
+        concatText: true,
+        titleKey: 'notify.chatMessages',
+        appearance: NOTIFICATION_TYPE.NORMAL,
+        icon: NOTIFICATION_ICON.MESSAGE
+    }, type);
+}
+
+/**
+ * An array of names of participants that have joined the conference. The array
+ * is replaced with an empty array as notifications are displayed.
+ *
+ * @private
+ * @type {string[]}
+ */
+let joinedParticipantsNames: string[] = [];
+
+/**
+ * A throttled internal function that takes the internal list of participant
+ * names, {@code joinedParticipantsNames}, and triggers the display of a
+ * notification informing of their joining.
+ *
+ * @private
+ * @type {Function}
+ */
+const _throttledNotifyParticipantConnected = throttle((dispatch: IStore['dispatch'], getState: IStore['getState']) => {
+    const participantCount = getParticipantCount(getState());
+
+    // Skip join notifications altogether for large meetings.
+    if (participantCount > SILENT_JOIN_THRESHOLD) {
+        joinedParticipantsNames = [];
+
+        return;
+    }
+
+    const joinedParticipantsCount = joinedParticipantsNames.length;
+
+    let notificationProps;
+
+    if (joinedParticipantsCount >= 3) {
+        notificationProps = {
+            titleArguments: {
+                name: joinedParticipantsNames[0]
+            },
+            titleKey: 'notify.connectedThreePlusMembers'
+        };
+    } else if (joinedParticipantsCount === 2) {
+        notificationProps = {
+            titleArguments: {
+                first: joinedParticipantsNames[0],
+                second: joinedParticipantsNames[1]
+            },
+            titleKey: 'notify.connectedTwoMembers'
+        };
+    } else if (joinedParticipantsCount) {
+        notificationProps = {
+            titleArguments: {
+                name: joinedParticipantsNames[0]
+            },
+            titleKey: 'notify.connectedOneMember'
+        };
+    }
+
+    if (notificationProps) {
+        dispatch(
+            showNotification(notificationProps, NOTIFICATION_TIMEOUT_TYPE.SHORT));
+    }
+
+    joinedParticipantsNames = [];
+
+}, 2000, { leading: false });
+
+/**
+ * An array of names of participants that have left the conference. The array
+ * is replaced with an empty array as notifications are displayed.
+ *
+ * @private
+ * @type {string[]}
+ */
+let leftParticipantsNames: string[] = [];
+
+/**
+ * A throttled internal function that takes the internal list of participant
+ * names, {@code leftParticipantsNames}, and triggers the display of a
+ * notification informing of their leaving.
+ *
+ * @private
+ * @type {Function}
+ */
+const _throttledNotifyParticipantLeft = throttle((dispatch: IStore['dispatch'], getState: IStore['getState']) => {
+    const participantCount = getParticipantCount(getState());
+
+    // Skip left notifications altogether for large meetings.
+    if (participantCount > SILENT_LEFT_THRESHOLD) {
+        leftParticipantsNames = [];
+
+        return;
+    }
+
+    const leftParticipantsCount = leftParticipantsNames.length;
+
+    let notificationProps;
+
+    if (leftParticipantsCount >= 3) {
+        notificationProps = {
+            titleArguments: {
+                name: leftParticipantsNames[0]
+            },
+            titleKey: 'notify.leftThreePlusMembers'
+        };
+    } else if (leftParticipantsCount === 2) {
+        notificationProps = {
+            titleArguments: {
+                first: leftParticipantsNames[0],
+                second: leftParticipantsNames[1]
+            },
+            titleKey: 'notify.leftTwoMembers'
+        };
+    } else if (leftParticipantsCount) {
+        notificationProps = {
+            titleArguments: {
+                name: leftParticipantsNames[0]
+            },
+            titleKey: 'notify.leftOneMember'
+        };
+    }
+
+    if (notificationProps) {
+        dispatch(
+            showNotification(notificationProps, NOTIFICATION_TIMEOUT_TYPE.SHORT));
+    }
+
+    leftParticipantsNames = [];
+
+}, 2000, { leading: false });
+
+/**
+ * Queues the display of a notification of a participant having connected to
+ * the meeting. The notifications are batched so that quick consecutive
+ * connection events are shown in one notification.
+ *
+ * @param {string} displayName - The name of the participant that connected.
+ * @returns {Function}
+ */
+export function showParticipantJoinedNotification(displayName: string) {
+    joinedParticipantsNames.push(displayName);
+
+    return (dispatch: IStore['dispatch'], getState: IStore['getState']) =>
+        _throttledNotifyParticipantConnected(dispatch, getState);
+}
+
+/**
+ * Queues the display of a notification of a participant having left to
+ * the meeting. The notifications are batched so that quick consecutive
+ * connection events are shown in one notification.
+ *
+ * @param {string} displayName - The name of the participant that left.
+ * @returns {Function}
+ */
+export function showParticipantLeftNotification(displayName: string) {
+    leftParticipantsNames.push(displayName);
+
+    return (dispatch: IStore['dispatch'], getState: IStore['getState']) =>
+        _throttledNotifyParticipantLeft(dispatch, getState);
+}

--- a/fishmeet/react/features/notifications/actions.ts
+++ b/fishmeet/react/features/notifications/actions.ts
@@ -95,16 +95,16 @@ export function setNotificationsEnabled(enabled: boolean) {
 }
 
 /**
- * The type of (redux) action which signals that the breakout room participant
+ * The type of (redux) action which signals that the breakout room participants
  * should be updated.
  *
- * @param {Object} participants - The breakout room participant.
+ * @param {Object} participants - The breakout room participants.
  * @returns {{
- *     type: SET_BREAKOUT_ROOM_PARTICIPANT,
- *     participant: Object
+ *     type: SET_BREAKOUT_ROOM_PARTICIPANTS,
+ *     participants: Object
  * }}
  */
-export function setBreakoutRoomParticipant(participants: IRoom['participants']) {
+export function setBreakoutRoomParticipants(participants: IRoom['participants']) {
     return {
         type: SET_BREAKOUT_ROOM_PARTICIPANTS,
         participants

--- a/fishmeet/react/features/notifications/constants.ts
+++ b/fishmeet/react/features/notifications/constants.ts
@@ -1,0 +1,132 @@
+export const FEATURE_KEY = 'features/notifications';
+
+/**
+ * The standard time when auto-disappearing notifications should disappear.
+ */
+export const NOTIFICATION_TIMEOUT = {
+    SHORT: 2500,
+    MEDIUM: 5000,
+    LONG: 10000,
+    EXTRA_LONG: 60000,
+    STICKY: false
+};
+
+/**
+ * Notification timeout type.
+ */
+export enum NOTIFICATION_TIMEOUT_TYPE {
+    EXTRA_LONG = 'extra_long',
+    LONG = 'long',
+    MEDIUM = 'medium',
+    SHORT = 'short',
+    STICKY = 'sticky'
+}
+
+/**
+ * The set of possible notification types.
+ *
+ * @enum {string}
+ */
+export const NOTIFICATION_TYPE = {
+    ERROR: 'error',
+    NORMAL: 'normal',
+    SUCCESS: 'success',
+    WARNING: 'warning'
+};
+
+/**
+ * A mapping of notification type to priority of display.
+ *
+ * @enum {number}
+ */
+export const NOTIFICATION_TYPE_PRIORITIES = {
+    [NOTIFICATION_TYPE.ERROR]: 5,
+    [NOTIFICATION_TYPE.NORMAL]: 3,
+    [NOTIFICATION_TYPE.SUCCESS]: 3,
+    [NOTIFICATION_TYPE.WARNING]: 4
+};
+
+/**
+ * The set of possible notification icons.
+ *
+ * @enum {string}
+ */
+export const NOTIFICATION_ICON = {
+    ...NOTIFICATION_TYPE,
+    MESSAGE: 'message',
+    PARTICIPANT: 'participant',
+    PARTICIPANTS: 'participants'
+};
+
+/**
+ * The identifier of the calendar notification.
+ *
+ * @type {string}
+ */
+export const CALENDAR_NOTIFICATION_ID = 'CALENDAR_NOTIFICATION_ID';
+
+/**
+ * The identifier of the disable self view notification.
+ *
+ * @type {string}
+ */
+export const DATA_CHANNEL_CLOSED_NOTIFICATION_ID = 'DATA_CHANNEL_CLOSED_NOTIFICATION_ID';
+
+/**
+ * The identifier of the disable self view notification.
+ *
+ * @type {string}
+ */
+export const DISABLE_SELF_VIEW_NOTIFICATION_ID = 'DISABLE_SELF_VIEW_NOTIFICATION_ID';
+
+/**
+ * The identifier of the lobby notification.
+ *
+ * @type {string}
+ */
+export const LOBBY_NOTIFICATION_ID = 'LOBBY_NOTIFICATION';
+
+/**
+ * The identifier of the local recording notification.
+ *
+ * @type {string}
+ */
+export const LOCAL_RECORDING_NOTIFICATION_ID = 'LOCAL_RECORDING_NOTIFICATION_ID';
+
+/**
+ * The identifier of the raise hand notification.
+ *
+ * @type {string}
+ */
+export const RAISE_HAND_NOTIFICATION_ID = 'RAISE_HAND_NOTIFICATION';
+
+/**
+ * The identifier of the salesforce link notification.
+ *
+ * @type {string}
+ */
+export const SALESFORCE_LINK_NOTIFICATION_ID = 'SALESFORCE_LINK_NOTIFICATION';
+
+/**
+ * The identifier of the visitors promotion notification.
+ *
+ * @type {string}
+ */
+export const VISITORS_PROMOTION_NOTIFICATION_ID = 'VISITORS_PROMOTION_NOTIFICATION';
+
+/**
+ * The identifier of the visitors notification indicating the meeting is not live.
+ *
+ * @type {string}
+ */
+export const VISITORS_NOT_LIVE_NOTIFICATION_ID = 'VISITORS_NOT_LIVE_NOTIFICATION_ID';
+
+/**
+ * Amount of participants beyond which no join notification will be emitted.
+ */
+export const SILENT_JOIN_THRESHOLD = 30;
+
+/**
+ * Amount of participants beyond which no left notification will be emitted.
+ */
+export const SILENT_LEFT_THRESHOLD = 30;

--- a/fishmeet/react/features/notifications/functions.ts
+++ b/fishmeet/react/features/notifications/functions.ts
@@ -2,7 +2,6 @@ import { find } from 'lodash-es';
 
 import { MODERATION_NOTIFICATIONS, MediaType } from '../av-moderation/constants';
 import { IStateful } from '../base/app/types';
-import { getParticipantDisplayName } from '../base/participants/functions';
 import { IParticipant } from '../base/participants/types';
 import { toState } from '../base/redux/functions';
 
@@ -55,7 +54,5 @@ export function isJoinFromBreakoutRoom(participant: IParticipant, stateful: ISta
     const state = toState(stateful);
     const { breakoutRoomParticipants } = state['features/notifications'];
 
-    const _isJoinFromBreakoutRoom = !!find(breakoutRoomParticipants, { displayName: getParticipantDisplayName(stateful, participant.id) });
-
-    return _isJoinFromBreakoutRoom;
+    return Boolean(find(breakoutRoomParticipants, (p, jid) => jid.endsWith(`/${participant.id}`)));
 }

--- a/fishmeet/react/features/notifications/functions.ts
+++ b/fishmeet/react/features/notifications/functions.ts
@@ -53,14 +53,9 @@ export function isModerationNotificationDisplayed(mediaType: MediaType, stateful
  */
 export function isJoinFromBreakoutRoom(participant: IParticipant, stateful: IStateful): boolean {
     const state = toState(stateful);
-
     const { breakoutRoomParticipants } = state['features/notifications'];
 
-    const displayName = getParticipantDisplayName(stateful, participant.id);
-
-    console.log('[GTS isJoinFromBreakoutRoom]', { displayName });
-
-    const _isJoinFromBreakoutRoom = !!find(breakoutRoomParticipants, { displayName });
+    const _isJoinFromBreakoutRoom = !!find(breakoutRoomParticipants, { displayName: getParticipantDisplayName(stateful, participant.id) });
 
     return _isJoinFromBreakoutRoom;
 }

--- a/fishmeet/react/features/notifications/functions.ts
+++ b/fishmeet/react/features/notifications/functions.ts
@@ -1,0 +1,61 @@
+import { find } from 'lodash-es';
+
+import { MODERATION_NOTIFICATIONS, MediaType } from '../av-moderation/constants';
+import { IStateful } from '../base/app/types';
+import { IParticipant } from '../base/participants/types';
+import { toState } from '../base/redux/functions';
+
+/**
+ * Tells whether or not the notifications are enabled and if there are any
+ * notifications to be displayed based on the current Redux state.
+ *
+ * @param {IStateful} stateful - The redux store state.
+ * @returns {boolean}
+ */
+export function areThereNotifications(stateful: IStateful) {
+    const state = toState(stateful);
+    const { enabled, notifications } = state['features/notifications'];
+
+    return enabled && notifications.length > 0;
+}
+
+/**
+ * Tells whether join/leave notifications are enabled in interface_config.
+ *
+ * @returns {boolean}
+ */
+export function joinLeaveNotificationsDisabled() {
+    return Boolean(typeof interfaceConfig !== 'undefined' && interfaceConfig?.DISABLE_JOIN_LEAVE_NOTIFICATIONS);
+}
+
+/**
+ * Returns whether or not the moderation notification for the given type is displayed.
+ *
+ * @param {MEDIA_TYPE} mediaType - The media type to check.
+ * @param {IStateful} stateful - The redux store state.
+ * @returns {boolean}
+ */
+export function isModerationNotificationDisplayed(mediaType: MediaType, stateful: IStateful) {
+    const state = toState(stateful);
+
+    const { notifications } = state['features/notifications'];
+
+    return Boolean(notifications.find(n => n.uid === MODERATION_NOTIFICATIONS[mediaType]));
+}
+
+/**
+ * Tells whether or not the participant participant is joining from a breakout room.
+ *
+ * @param {IParticipant} participant - The participant to check.
+ * @param {IStateful} stateful - The redux store state.
+ * @returns {boolean}
+ */
+export function isJoinFromBreakoutRoom(participant: IParticipant, stateful: IStateful): boolean {
+    const state = toState(stateful);
+
+    const { breakoutRoomParticipants } = state['features/notifications'];
+
+    const _isJoinFromBreakoutRoom = !!find(breakoutRoomParticipants, { displayName: participant.name });
+
+    return _isJoinFromBreakoutRoom;
+}

--- a/fishmeet/react/features/notifications/functions.ts
+++ b/fishmeet/react/features/notifications/functions.ts
@@ -2,6 +2,7 @@ import { find } from 'lodash-es';
 
 import { MODERATION_NOTIFICATIONS, MediaType } from '../av-moderation/constants';
 import { IStateful } from '../base/app/types';
+import { getParticipantDisplayName } from '../base/participants/functions';
 import { IParticipant } from '../base/participants/types';
 import { toState } from '../base/redux/functions';
 
@@ -55,7 +56,11 @@ export function isJoinFromBreakoutRoom(participant: IParticipant, stateful: ISta
 
     const { breakoutRoomParticipants } = state['features/notifications'];
 
-    const _isJoinFromBreakoutRoom = !!find(breakoutRoomParticipants, { displayName: participant.name });
+    const displayName = getParticipantDisplayName(stateful, participant.id);
+
+    console.log('[GTS isJoinFromBreakoutRoom]', { displayName });
+
+    const _isJoinFromBreakoutRoom = !!find(breakoutRoomParticipants, { displayName });
 
     return _isJoinFromBreakoutRoom;
 }

--- a/fishmeet/react/features/notifications/logger.ts
+++ b/fishmeet/react/features/notifications/logger.ts
@@ -1,0 +1,5 @@
+import { getLogger } from '../base/logging/functions';
+
+import { FEATURE_KEY } from './constants';
+
+export default getLogger(FEATURE_KEY);

--- a/fishmeet/react/features/notifications/middleware.ts
+++ b/fishmeet/react/features/notifications/middleware.ts
@@ -1,0 +1,250 @@
+import { throttle, values } from 'lodash-es';
+
+import { IReduxState, IStore } from '../app/types';
+import { getCurrentConference } from '../base/conference/functions';
+import { JitsiConferenceEvents } from '../base/lib-jitsi-meet';
+import {
+    PARTICIPANT_JOINED,
+    PARTICIPANT_LEFT,
+    PARTICIPANT_UPDATED
+} from '../base/participants/actionTypes';
+import { PARTICIPANT_ROLE } from '../base/participants/constants';
+import {
+    getLocalParticipant,
+    getParticipantById,
+    getParticipantDisplayName,
+    isScreenShareParticipant,
+    isWhiteboardParticipant
+} from '../base/participants/functions';
+import MiddlewareRegistry from '../base/redux/MiddlewareRegistry';
+import StateListenerRegistry from '../base/redux/StateListenerRegistry';
+import type { IRooms } from '../breakout-rooms/types';
+import { PARTICIPANTS_PANE_OPEN } from '../participants-pane/actionTypes';
+
+import {
+    CLEAR_NOTIFICATIONS,
+    HIDE_NOTIFICATION,
+    SHOW_NOTIFICATION
+} from './actionTypes';
+import {
+    clearNotifications,
+    hideNotification,
+    setBreakoutRoomParticipant,
+    showNotification,
+    showParticipantJoinedNotification,
+    showParticipantLeftNotification
+} from './actions';
+import {
+    NOTIFICATION_TIMEOUT_TYPE,
+    RAISE_HAND_NOTIFICATION_ID
+} from './constants';
+import { areThereNotifications, isJoinFromBreakoutRoom, joinLeaveNotificationsDisabled } from './functions';
+import logger from './logger';
+
+/**
+ * Map of timers.
+ *
+ * @type {Map}
+ */
+const timers = new Map();
+
+/**
+ * Function that creates a timeout id for specific notification.
+ *
+ * @param {Object} notification - Notification for which we want to create a timeout.
+ * @param {Function} dispatch - The Redux dispatch function.
+ * @returns {void}
+ */
+const createTimeoutId = (notification: { timeout: number; uid: string; }, dispatch: IStore['dispatch']) => {
+    const {
+        timeout,
+        uid
+    } = notification;
+
+    if (timeout) {
+        const timerID = setTimeout(() => {
+            dispatch(hideNotification(uid));
+        }, timeout);
+
+        timers.set(uid, timerID);
+    }
+};
+
+/**
+ * Returns notifications state.
+ *
+ * @param {Object} state - Global state.
+ * @returns {Array<Object>} - Notifications state.
+ */
+const getNotifications = (state: IReduxState) => {
+    const _visible = areThereNotifications(state);
+    const { notifications } = state['features/notifications'];
+
+    return _visible ? notifications : [];
+};
+
+/**
+ * Middleware that captures actions to display notifications.
+ *
+ * @param {Store} store - The redux store.
+ * @returns {Function}
+ */
+MiddlewareRegistry.register(store => next => action => {
+    const { dispatch, getState } = store;
+    const state = getState();
+
+    switch (action.type) {
+    case CLEAR_NOTIFICATIONS: {
+        const _notifications = getNotifications(state);
+
+        for (const notification of _notifications) {
+            if (timers.has(notification.uid)) {
+                const timeout = timers.get(notification.uid);
+
+                clearTimeout(timeout);
+                timers.delete(notification.uid);
+            }
+        }
+        timers.clear();
+        break;
+    }
+    case SHOW_NOTIFICATION: {
+        if (timers.has(action.uid)) {
+            const timer = timers.get(action.uid);
+
+            clearTimeout(timer);
+            timers.delete(action.uid);
+        }
+
+        createTimeoutId(action, dispatch);
+        break;
+    }
+    case HIDE_NOTIFICATION: {
+        const timer = timers.get(action.uid);
+
+        clearTimeout(timer);
+        timers.delete(action.uid);
+        break;
+    }
+    case PARTICIPANT_JOINED: {
+        const result = next(action);
+        const { participant: p } = action;
+        const { conference } = state['features/base/conference'];
+
+        console.log('[GTS notifications middleware] PARTICIPANT_JOINED', {
+            action,
+            participant: p
+        });
+
+        // Do not display notifications for the virtual screenshare and whiteboard tiles.
+        if (conference
+            && !p.local
+            && !isScreenShareParticipant(p)
+            && !isWhiteboardParticipant(p)
+            && !joinLeaveNotificationsDisabled()
+            && !isJoinFromBreakoutRoom(p, state)
+            && !p.isReplacing) {
+            dispatch(showParticipantJoinedNotification(
+                getParticipantDisplayName(state, p.id)
+            ));
+        }
+
+        return result;
+    }
+    case PARTICIPANT_LEFT: {
+        if (!joinLeaveNotificationsDisabled()) {
+            const participant = getParticipantById(
+                store.getState(),
+                action.participant.id
+            );
+
+            // Do not display notifications for the virtual screenshare tiles.
+            if (participant
+                && !participant.local
+                && !isScreenShareParticipant(participant)
+                && !isWhiteboardParticipant(participant)
+                && !action.participant.isReplaced) {
+                dispatch(showParticipantLeftNotification(
+                    getParticipantDisplayName(state, participant.id)
+                ));
+            }
+        }
+
+        return next(action);
+    }
+    case PARTICIPANT_UPDATED: {
+        const { disableModeratorIndicator } = state['features/base/config'];
+
+        if (disableModeratorIndicator) {
+            return next(action);
+        }
+
+        const { id, role } = action.participant;
+        const localParticipant = getLocalParticipant(state);
+
+        if (localParticipant?.id !== id) {
+            return next(action);
+        }
+
+        const oldParticipant = getParticipantById(state, id);
+        const oldRole = oldParticipant?.role;
+
+        if (oldRole && oldRole !== role && role === PARTICIPANT_ROLE.MODERATOR) {
+
+            store.dispatch(showNotification({
+                titleKey: 'notify.moderator'
+            },
+            NOTIFICATION_TIMEOUT_TYPE.SHORT));
+        }
+
+        return next(action);
+    }
+    case PARTICIPANTS_PANE_OPEN: {
+        store.dispatch(hideNotification(RAISE_HAND_NOTIFICATION_ID));
+        break;
+    }
+    }
+
+    return next(action);
+});
+
+/**
+ * StateListenerRegistry provides a reliable way to detect the leaving of a
+ * conference, where we need to clean up the notifications.
+ */
+StateListenerRegistry.register(
+    /* selector */ state => getCurrentConference(state),
+    /* listener */ (conference, { dispatch }) => {
+        if (!conference) {
+            dispatch(clearNotifications());
+        }
+    }
+);
+
+/**
+ * StateListenerRegistry provides a reliable way to detect the breakout rooms updated event,
+ * where we need to update the breakout room participants.
+ */
+StateListenerRegistry.register(
+    state => state['features/base/conference'].conference,
+    (conference, { dispatch }, previousConference) => {
+        if (conference && !previousConference) {
+            conference.on(JitsiConferenceEvents.BREAKOUT_ROOMS_UPDATED, throttle((params: { rooms: IRooms; }) => {
+                const { rooms } = params;
+                const breakoutRoomParticipants = values(rooms).filter(room => !room.isMainRoom).reduce((acc, room) => ({
+                    ...acc,
+                    ...room?.participants
+                }), {});
+
+                logger.debug('[GTS] notifications Room Updated:', {
+                    rooms,
+                    breakoutRoomParticipants
+                });
+
+                dispatch(setBreakoutRoomParticipant(breakoutRoomParticipants));
+            }, 3000, {
+                leading: false,
+                trailing: true
+            }));
+        }
+    });

--- a/fishmeet/react/features/notifications/middleware.ts
+++ b/fishmeet/react/features/notifications/middleware.ts
@@ -29,7 +29,7 @@ import {
 import {
     clearNotifications,
     hideNotification,
-    setBreakoutRoomParticipant,
+    setBreakoutRoomParticipants,
     showNotification,
     showParticipantJoinedNotification,
     showParticipantLeftNotification
@@ -236,7 +236,7 @@ StateListenerRegistry.register(
                     breakoutRoomParticipants
                 });
 
-                dispatch(setBreakoutRoomParticipant(breakoutRoomParticipants));
+                dispatch(setBreakoutRoomParticipants(breakoutRoomParticipants));
             }, 3000, {
                 leading: false,
                 trailing: true

--- a/fishmeet/react/features/notifications/middleware.ts
+++ b/fishmeet/react/features/notifications/middleware.ts
@@ -131,11 +131,6 @@ MiddlewareRegistry.register(store => next => action => {
         const { participant: p } = action;
         const { conference } = state['features/base/conference'];
 
-        console.log('[GTS notifications middleware] PARTICIPANT_JOINED', {
-            action,
-            participant: p
-        });
-
         // Do not display notifications for the virtual screenshare and whiteboard tiles.
         if (conference
             && !p.local

--- a/fishmeet/react/features/notifications/reducer.ts
+++ b/fishmeet/react/features/notifications/reducer.ts
@@ -4,7 +4,7 @@ import { IRoom } from '../breakout-rooms/types';
 import {
     CLEAR_NOTIFICATIONS,
     HIDE_NOTIFICATION,
-    SET_BREAKOUT_ROOM_PARTICIPANT,
+    SET_BREAKOUT_ROOM_PARTICIPANTS,
     SET_NOTIFICATIONS_ENABLED,
     SHOW_NOTIFICATION
 } from './actionTypes';
@@ -75,7 +75,7 @@ ReducerRegistry.register<INotificationsState>('features/notifications',
          * @param {IRoom['participants']} participants - The breakout room participants.
          * @returns {Object}
          */
-        case SET_BREAKOUT_ROOM_PARTICIPANT:
+        case SET_BREAKOUT_ROOM_PARTICIPANTS:
             return {
                 ...state,
                 breakoutRoomParticipants: action.participants

--- a/fishmeet/react/features/notifications/reducer.ts
+++ b/fishmeet/react/features/notifications/reducer.ts
@@ -70,7 +70,7 @@ ReducerRegistry.register<INotificationsState>('features/notifications',
             };
 
         /**
-         * Sets the breakout room participants.
+         * Sets the breakout room participant.
          *
          * @param {IRoom['participants']} participants - The breakout room participants.
          * @returns {Object}

--- a/fishmeet/react/features/notifications/reducer.ts
+++ b/fishmeet/react/features/notifications/reducer.ts
@@ -1,0 +1,148 @@
+import ReducerRegistry from '../base/redux/ReducerRegistry';
+import { IRoom } from '../breakout-rooms/types';
+
+import {
+    CLEAR_NOTIFICATIONS,
+    HIDE_NOTIFICATION,
+    SET_BREAKOUT_ROOM_PARTICIPANT,
+    SET_NOTIFICATIONS_ENABLED,
+    SHOW_NOTIFICATION
+} from './actionTypes';
+import { NOTIFICATION_TYPE_PRIORITIES } from './constants';
+
+
+/**
+ * The initial state of the feature notifications.
+ *
+ * @type {array}
+ */
+const DEFAULT_STATE = {
+    enabled: true,
+    notifications: [],
+    breakoutRoomParticipants: {}
+};
+
+interface INotification {
+    component: Object;
+    props: {
+        appearance?: string;
+        descriptionArguments?: Object;
+        descriptionKey?: string;
+        titleKey: string;
+    };
+    timeout: number;
+    uid: string;
+}
+
+export interface INotificationsState {
+    breakoutRoomParticipants: IRoom['participants'];
+    enabled: boolean;
+    notifications: INotification[];
+}
+
+/**
+ * Reduces redux actions which affect the display of notifications.
+ *
+ * @param {Object} state - The current redux state.
+ * @param {Object} action - The redux action to reduce.
+ * @returns {Object} The next redux state which is the result of reducing the
+ * specified {@code action}.
+ */
+ReducerRegistry.register<INotificationsState>('features/notifications',
+    (state = DEFAULT_STATE, action): INotificationsState => {
+        switch (action.type) {
+        case CLEAR_NOTIFICATIONS:
+            return {
+                ...state,
+                notifications: []
+            };
+        case HIDE_NOTIFICATION:
+            return {
+                ...state,
+                notifications: state.notifications.filter(
+                    notification => notification.uid !== action.uid)
+            };
+
+        case SET_NOTIFICATIONS_ENABLED:
+            return {
+                ...state,
+                enabled: action.enabled
+            };
+
+        /**
+         * Sets the breakout room participants.
+         *
+         * @param {IRoom['participants']} participants - The breakout room participants.
+         * @returns {Object}
+         */
+        case SET_BREAKOUT_ROOM_PARTICIPANT:
+            return {
+                ...state,
+                breakoutRoomParticipants: action.participants
+            };
+
+        case SHOW_NOTIFICATION:
+            return {
+                ...state,
+                notifications:
+                    _insertNotificationByPriority(state.notifications, {
+                        component: action.component,
+                        props: action.props,
+                        timeout: action.timeout,
+                        uid: action.uid
+                    })
+            };
+        }
+
+        return state;
+    });
+
+/**
+ * Creates a new notification queue with the passed in notification placed at
+ * the end of other notifications with higher or the same priority.
+ *
+ * @param {Object[]} notifications - The queue of notifications to be displayed.
+ * @param {Object} notification - The new notification to add to the queue.
+ * @private
+ * @returns {Object[]} A new array with an updated order of the notification
+ * queue.
+ */
+function _insertNotificationByPriority(notifications: INotification[], notification: INotification) {
+
+    // Create a copy to avoid mutation.
+    const copyOfNotifications = notifications.slice();
+
+    // Get the index of any queued notification that has the same id as the new notification
+    let insertAtLocation = copyOfNotifications.findIndex(
+            (queuedNotification: INotification) =>
+                queuedNotification?.uid === notification?.uid
+    );
+
+    if (insertAtLocation !== -1) {
+        copyOfNotifications.splice(insertAtLocation, 1, notification);
+
+        return copyOfNotifications;
+    }
+
+    const newNotificationPriority
+        = NOTIFICATION_TYPE_PRIORITIES[notification.props.appearance ?? ''] || 0;
+
+    // Find where to insert the new notification based on priority. Do not
+    // insert at the front of the queue so that the user can finish acting on
+    // any notification currently being read.
+    for (let i = 1; i < notifications.length; i++) {
+        const queuedNotification = notifications[i];
+        const queuedNotificationPriority
+            = NOTIFICATION_TYPE_PRIORITIES[queuedNotification.props.appearance ?? '']
+            || 0;
+
+        if (queuedNotificationPriority < newNotificationPriority) {
+            insertAtLocation = i;
+            break;
+        }
+    }
+
+    copyOfNotifications.splice(insertAtLocation, 0, notification);
+
+    return copyOfNotifications;
+}


### PR DESCRIPTION
## Main changes

Review this pr diff on https://github.com/gracetech-services/jitsi-meet/pull/60

- Add relevant actions, reducers and functional functions for venue participants
- Add log recording function
- Process venue participant join notifications in the middleware
- Listen for venue update events and update participant status


## Preivew

https://github.com/user-attachments/assets/e26f003b-54a7-4b0f-b608-931332a2581f

