### PR TITLE
【Don Not Merge】just for showing diff suppression notification  planB

### DIFF
--- a/react/features/base/conference/middleware.web.ts
+++ b/react/features/base/conference/middleware.web.ts
@@ -1,5 +1,7 @@
 import i18next from 'i18next';
 
+import { rescueToMainRoom } from '../../breakout-rooms/actions';
+import { isInBreakoutRoom } from '../../breakout-rooms/functions';
 import {
     setPrejoinPageVisibility,
     setSkipPrejoinOnReload
@@ -125,13 +127,22 @@ MiddlewareRegistry.register(store => next => action => {
 
         if (errorName === JitsiConferenceErrors.CONFERENCE_DESTROYED) {
             const state = getState();
-            const { notifyOnConferenceDestruction = true } = state['features/base/config'];
-            const [ reason ] = action.error.params;
-            const titlekey = Object.keys(TRIGGER_READY_TO_CLOSE_REASONS)[
-                Object.values(TRIGGER_READY_TO_CLOSE_REASONS).indexOf(reason)
-            ];
+            const inBreakoutRoom = isInBreakoutRoom(state);
 
-            dispatch(hangup(true, i18next.t(titlekey) || reason, notifyOnConferenceDestruction));
+            if (inBreakoutRoom) {
+                // Sub-meeting room destroyed — Redirect to main meeting room
+                dispatch(rescueToMainRoom());
+            } else {
+
+                const { notifyOnConferenceDestruction = true } = state['features/base/config'];
+                const [ reason ] = action.error.params;
+                const titlekey = Object.keys(TRIGGER_READY_TO_CLOSE_REASONS)[
+                    Object.values(TRIGGER_READY_TO_CLOSE_REASONS).indexOf(reason)
+                ];
+
+                dispatch(hangup(true, i18next.t(titlekey) || reason, notifyOnConferenceDestruction));
+            }
+
         }
 
         releaseScreenLock();

--- a/react/features/breakout-rooms/actions.ts
+++ b/react/features/breakout-rooms/actions.ts
@@ -11,6 +11,7 @@ import {
 } from '../base/conference/actions';
 import { CONFERENCE_LEAVE_REASONS } from '../base/conference/constants';
 import { getCurrentConference } from '../base/conference/functions';
+import { hangup } from '../base/connection/actions';
 import { setAudioMuted, setVideoMuted } from '../base/media/actions';
 import { MEDIA_TYPE } from '../base/media/constants';
 import { getRemoteParticipants } from '../base/participants/functions';
@@ -85,8 +86,10 @@ export function closeBreakoutRoom(roomId: string) {
                 prList.push(dispatch(sendParticipantToRoom(participant.jid, mainRoom.id)));
             });
 
-            // GTS: Return an asynchronous callback to make closeBreakoutRoom more predictable.
-            return Promise.all(prList);
+            // GTS: await an asynchronous callback to make closeBreakoutRoom more predictable.
+            await Promise.all(prList);
+
+            dispatch(removeBreakoutRoom(room.jid));
         }
     };
 }
@@ -127,9 +130,10 @@ export function removeBreakoutRoom(breakoutRoomJid: string) {
             return;
         }
 
-        if (Object.keys(room.participants).length > 0) {
-            await dispatch(closeBreakoutRoom(room.id));
-        }
+        // GTS: Close the room whatever it has participants.
+        // if (Object.keys(room.participants).length > 0) {
+        //     await dispatch(closeBreakoutRoom(room.id));
+        // }
 
         console.log('[GTS] getBreakoutRooms().removeBreakoutRoom: removing room', breakoutRoomJid);
 
@@ -338,4 +342,62 @@ function _findParticipantJid(getState: IStore['getState'], participantId: string
     }
 
     return participantJid;
+}
+
+let _rescueInProgress = false;
+
+export function rescueToMainRoom() {
+    return async (dispatch: IStore['dispatch'], getState: IStore['getState']) => {
+        if (_rescueInProgress) {
+            logger.debug('Rescue in progress, skipping');
+
+            return;
+        }
+        _rescueInProgress = true;
+
+        try {
+            const mainRoomId = getMainRoom(getState)?.id;
+
+            if (!mainRoomId) {
+                logger.warn('Failed to rescue meeting to main meeting room: Main meeting room not found');
+                dispatch(hangup(true, i18next.t('dialog.sessTerminatedReason'), true));
+
+                return;
+            }
+
+            // Clear the sub-meeting room state
+            dispatch({ type: _RESET_BREAKOUT_ROOMS });
+
+            if (navigator.product === 'ReactNative') {
+                // Mobile process: Join the main meeting room if the sub-meeting room is destroyed
+                const { audio, video } = getState()['features/base/media'];
+
+                dispatch(clearNotifications());
+                dispatch(createConference(mainRoomId));
+                dispatch(setAudioMuted(audio.muted));
+                dispatch(setVideoMuted(Boolean(video.muted)));
+                dispatch(createDesiredLocalTracks());
+            } else {
+                // Web process: Attempt to leave the destroyed meeting room (failure may occur, which is normal)
+                try {
+                    await APP.conference.leaveRoom(
+                        false, CONFERENCE_LEAVE_REASONS.SWITCH_ROOM
+                    );
+                } catch (error) {
+                    logger.warn('Failed cue process: leaveRoom() failed (normal behavior when meeting room is destroyed):', error);
+                }
+
+                const localTracks = getLocalTracks(getState()['features/base/tracks']);
+
+                // Join the main meeting room
+                APP.conference.joinRoom(mainRoomId, {
+                    startWithAudioMuted: isLocalTrackMuted(localTracks, MEDIA_TYPE.AUDIO),
+                    startWithVideoMuted: isLocalTrackMuted(localTracks, MEDIA_TYPE.VIDEO)
+                });
+            }
+
+        } finally {
+            _rescueInProgress = false;
+        }
+    };
 }

--- a/react/features/notifications/middleware.ts
+++ b/react/features/notifications/middleware.ts
@@ -77,6 +77,21 @@ const getNotifications = (state: IReduxState) => {
     return _visible ? notifications : [];
 };
 
+let suppressUntil = 0;
+
+StateListenerRegistry.register(
+    state =>
+        Object.values(state['features/breakout-rooms'].rooms ?? {}).filter(
+            (r: any) => !r.isMainRoom
+        ).length,
+    (count, _, prevCount) => {
+        if ((prevCount ?? 0) > count) {
+            suppressUntil = Date.now() + 5000;
+        }
+    }
+);
+
+
 /**
  * Middleware that captures actions to display notifications.
  *
@@ -131,7 +146,8 @@ MiddlewareRegistry.register(store => next => action => {
             && !isScreenShareParticipant(p)
             && !isWhiteboardParticipant(p)
             && !joinLeaveNotificationsDisabled()
-            && !p.isReplacing) {
+            && !p.isReplacing
+            && Date.now() > suppressUntil) {
             dispatch(showParticipantJoinedNotification(
                 getParticipantDisplayName(state, p.id)
             ));

--- a/react/features/participants-pane/components/breakout-rooms/components/web/RoomContextMenu.tsx
+++ b/react/features/participants-pane/components/breakout-rooms/components/web/RoomContextMenu.tsx
@@ -75,7 +75,7 @@ export const RoomContextMenu = ({
     }, [ dispatch, room ]);
 
     const onCloseBreakoutRoom = useCallback(() => {
-        dispatch(closeBreakoutRoom(room?.id ?? ''));
+        dispatch(removeBreakoutRoom(room?.jid ?? '')); // fishmeet: origin was dispatch(closeBreakoutRoom(room?.id ?? ''));
     }, [ dispatch, room ]);
 
     const isRoomEmpty = !(room?.participants && Object.keys(room.participants).length > 0);


### PR DESCRIPTION
fix(breakout-rooms): Add notification suppression logic when breakout rooms are destroyed

- Fix the issue of incorrect redirection to the main meeting room when breakout rooms are destroyed


## Description
## Fishmeet Customization Checklist
*These checks ensure we maintain the "Overlay" architecture and minimize upstream update costs.*

### 🏗 Architecture & Overrides
- [ ] **No direct core edits:** Does this PR avoid manual modifications to `react/` or `css/` files?
- [ ] **Placement:** Are all fishmeet-specific customizations located under the `fishmeet/` directory?
- [ ] **Directory Mirroring:** Do files in `fishmeet/react/` mirror the exact path of the core files they intend to replace?

### 🛠 Core Extension Points (If core files WERE modified)
- [ ] **Minimalism:** Is the core change small enough that a full override wasn't justified?
- [ ] **Access Pattern:** Does it use the `(styles as any).propName` pattern to read optional properties?
- [ ] **No Branding Logic:** Did you avoid adding `if (appType.isFishMeet)` inside core files?

### 🎨 Styles & Assets
- [ ] **Design Tokens:** Are all colors referencing `BaseTheme.palette.fishMeet*` (no hex values)?
- [ ] **Annotations:** Are all overridden style properties annotated with `// fishmeet: was <original value>`?
- [ ] **Icons:** Are new branded icons placed in `fishmeet/react/features/base/icons/svg/`?

### ⚠️ Maintenance Liability
- [ ] **TSX Overrides:** If a full `.tsx` file was overridden, is it absolutely necessary, or can a stylesheet suffice?
- [ ] **Config:** Are feature flags added to `config.js` and `configType.ts` for server-side control?

