### PR TITLE
Fix: sdk NPE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ local.properties
 # node.js
 #
 node_modules/
+node_modules
 npm-debug.log
 yarn-error.log
 

--- a/fishmeet/react/features/base/ui/Tokens.ts
+++ b/fishmeet/react/features/base/ui/Tokens.ts
@@ -9,8 +9,12 @@ export const colorMap = {
 
     // GraceTech Customization design token
     // Do not hardcode the colors:
-    // define them at type GraceTechCustomizedPalette: react/features/base/ui/functions.web.ts:9
-    // config them at fishmeet-config.js -》 config.customTheme
+    // for Web：
+    //   define them at type GraceTechCustomizedPalette: react/features/base/ui/functions.web.ts:9
+    //   config them at fishmeet-config.js -》 config.customTheme
+    // for Native：
+    //   for now, the native side does not support reading direct color values from the config, requiring extensive modifications, especially on the consumer side.
+    //   so let's trade off, define & config them at: fishmeet/react/features/base/ui/jitsiTokens.json
     customizedUiBackground: 'customizedUiBackground',
     customizedUiSecBackground: 'customizedUiSecBackground',
     customizedUiMainColor01: 'customizedUiMainColor01',

--- a/fishmeet/react/features/base/ui/jitsiTokens.json
+++ b/fishmeet/react/features/base/ui/jitsiTokens.json
@@ -1,0 +1,23 @@
+{
+    "success05": "#1EC26A",
+
+    "support05": "#73348C",
+    "support06": "#6A50D3",
+
+    "surface01": "#040404",
+    "surface02": "#141414",
+    "surface03": "#292929",
+    "surface05": "#525252",
+    "surface08": "#A3A3A3",
+
+    "warning06": "#FFD600",
+
+    "customizedUiBackground": "#42434F",
+    "customizedUiSecBackground": "#656876",
+    "customizedUiMainColor01": "#FE9C75",
+    "customizedUiMainColor02": "#C8D7EC",
+    "customizedUiAction01": "#E7EEF2",
+    "customizedUiText01": "#424350",
+    "customizedUiText02": "#28262C",
+    "customizedUiText03": "#33333F"
+}

--- a/fishmeet/react/features/toolbox/components/native/Toolbox.tsx
+++ b/fishmeet/react/features/toolbox/components/native/Toolbox.tsx
@@ -75,7 +75,7 @@ function Toolbox(props: IProps) {
     const backgroundToggledStyle = {
         ...toggledButtonStyles,
         style: [
-            toggledButtonStyles.style,
+            toggledButtonStyles?.style,
             _styles.backgroundToggle
         ]
     };

--- a/react/features/reactions/components/native/ReactionButton.tsx
+++ b/react/features/reactions/components/native/ReactionButton.tsx
@@ -78,7 +78,7 @@ interface IProps extends WithTranslation {
 function ReactionButton({
     children,
     onClick,
-    styles,
+    styles = {} as IReactionStyles, // fishmeet fix: NPE
     reaction,
     t
 }: IProps) {


### PR DESCRIPTION
## Description

- chore: Update configuration instructions for custom UI color tokens 
- fix(ReactionButton、toolbox): styles cause NPE

<img width="308" height="716" alt="iShot_2026-05-14_14 41 32" src="https://github.com/user-attachments/assets/6648d880-cb69-4724-9850-fa87683342c0" />
<img width="308" height="716" alt="iShot_2026-05-14_14 37 44" src="https://github.com/user-attachments/assets/c40057ec-cbe7-4427-8564-b6209d8ca621" />


## Fishmeet Customization Checklist
*These checks ensure we maintain the "Overlay" architecture and minimize upstream update costs.*

### 🏗 Architecture & Overrides
- [ ] **No direct core edits:** Does this PR avoid manual modifications to `react/` or `css/` files?
- [ ] **Placement:** Are all fishmeet-specific customizations located under the `fishmeet/` directory?
- [ ] **Directory Mirroring:** Do files in `fishmeet/react/` mirror the exact path of the core files they intend to replace?

### 🛠 Core Extension Points (If core files WERE modified)
- [ ] **Minimalism:** Is the core change small enough that a full override wasn't justified?
- [ ] **Access Pattern:** Does it use the `(styles as any).propName` pattern to read optional properties?
- [ ] **No Branding Logic:** Did you avoid adding `if (appType.isFishMeet)` inside core files?

### 🎨 Styles & Assets
- [ ] **Design Tokens:** Are all colors referencing `BaseTheme.palette.fishMeet*` (no hex values)?
- [ ] **Annotations:** Are all overridden style properties annotated with `// fishmeet: was <original value>`?
- [ ] **Icons:** Are new branded icons placed in `fishmeet/react/features/base/icons/svg/`?

### ⚠️ Maintenance Liability
- [ ] **TSX Overrides:** If a full `.tsx` file was overridden, is it absolutely necessary, or can a stylesheet suffice?
- [ ] **Config:** Are feature flags added to `config.js` and `configType.ts` for server-side control?

